### PR TITLE
update templates/report_template.html items to items()

### DIFF
--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -216,7 +216,7 @@
                                             class='material-icons'>low_priority</i></td>
                                     <td class='timestamp'>req_headers</td>
                                     <td class='step-details'>
-                                        {% for key, value in record.meta_data.request_headers.items %}
+                                        {% for key, value in record.meta_data.request_headers.items() %}
                                             <div>
                                                 <strong>{{ key }}</strong>: {{ value | safe }}
                                             </div>
@@ -233,7 +233,7 @@
                                             class='material-icons'>low_priority</i></td>
                                     <td class='timestamp'>resp_headers</td>
                                     <td class='step-details'>
-                                        {% for key, value in record.meta_data.response_headers.items %}
+                                        {% for key, value in record.meta_data.response_headers.items() %}
                                             <div>
                                                 <strong>{{ key }}</strong>: {{ value | safe }}
                                             </div>


### PR DESCRIPTION
## 关于测试报告  
每次的测试报告内容最好在数据库有存档，方便用户后期查询以前的执行记录等。
所以我本地处理了一些数据库表字段，按照httprunner保存报告的形式修改了下run_test()方法用来记录测试报告内容，但是报告生成保存到本地的过程中，report_template.html模板有些问题导致保存html失败，然后定位到了问题，处理办法将report_template.html中
```
{% for key, value in record.meta_data.request_headers.items %}
                                            <div>
                                                <strong>{{ key }}</strong>: {{ value | safe }}
                                            </div>
                                        {% endfor %}</td>
```
 将两个遍历dict的items 改为 items()， 执行报告、本地保存html报告数据内容均ok，经我自己的一些测试没有发现其他问题。